### PR TITLE
Update the README to show how to provision and downgrade OpenJFX

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,6 +5,9 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
+    ignore:
+      - dependency-name: 'org.openjfx:javafx-controls'
+        update-types: ['version-update:semver-major', 'version-update:semver-minor']
 
   - package-ecosystem: "maven"
     directory: "/"

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -25,7 +25,7 @@ jobs:
           cache: maven
       - name: Install
         id: install
-        run: $MVN install
+        run: $MVN install -Pexamples
 
   format-check:
     name: Check Code Formatting
@@ -40,7 +40,7 @@ jobs:
           distribution: 'temurin'
           cache: 'maven'
       - name: Format Source
-        run: "mvn -B clean install -DskipTests formatter:format"
+        run: "mvn -B clean install -DskipTests formatter:format -Pexamples"
       - name: Check for changes
         run:  |
           [ -z "$(git status --porcelain=v1 2>/dev/null)" ] || (echo -e "::error ::Changes have been found\n$(git diff)" && exit 1)

--- a/README.md
+++ b/README.md
@@ -12,8 +12,49 @@ To build the feature pack, simply run
 mvn install
 ```
 
-This will build everything, and run the testsuite. A WildFly server with the gRPC subsystem will be created in
-the `testsuite/integration/subsystem/target` directory.
+This will build everything, and run the testsuite.
+
+Once built you can provision a server with gRPC support using Galleon provisioning. An example using the 
+`org.wildfly.plugins:wildfly-maven-plugin`:
+
+```xml
+<plugin>
+    <groupId>org.wildfly.plugins</groupId>
+    <artifactId>wildfly-maven-plugin</artifactId>
+    <configuration>
+        <feature-packs>
+            <feature-pack>
+                <groupId>org.wildfly</groupId>
+                <artifactId>wildfly-galleon-pack</artifactId>
+                <version>${version.wildfly}</version>
+            </feature-pack>
+            <feature-pack>
+                <groupId>org.wildfly.extras.grpc</groupId>
+                <artifactId>wildfly-grpc-feature-pack</artifactId>
+                <version>${version.wildfly.grpc}</version>
+            </feature-pack>
+        </feature-packs>
+        <layers>
+            <layer>core-server</layer>
+            <layer>web-server</layer>
+            <layer>grpc</layer>
+        </layers>
+        <galleon-options>
+            <jboss-fork-embedded>${galleon.fork.embedded}</jboss-fork-embedded>
+        </galleon-options>
+        <provisioning-dir>wildfly</provisioning-dir>
+        <log-provisioning-time>${galleon.log.time}</log-provisioning-time>
+        <offline>true</offline>
+    </configuration>
+</plugin>
+```
+
+You can also configure this with the Galleon CLI tool:
+
+```bash
+galleon.sh install org.wildfly:wildfly-galleon-pack:$WILDFLY_VERSION --dir=wildfly-grpc
+galleon.sh install org.wildfly.extras.grpc:wildfly-grpc-feature-pack:$GRPC_VERSION --dir=wildfly-grpc
+```
 
 # Examples
 

--- a/examples/chat/client/src/main/java/com/example/grpc/chat/ChatClient.java
+++ b/examples/chat/client/src/main/java/com/example/grpc/chat/ChatClient.java
@@ -27,7 +27,6 @@ import io.grpc.ManagedChannel;
 import io.grpc.ManagedChannelBuilder;
 import io.grpc.TlsChannelCredentials;
 import io.grpc.stub.StreamObserver;
-
 import javafx.application.Application;
 import javafx.application.Platform;
 import javafx.collections.FXCollections;

--- a/examples/chat/pom.xml
+++ b/examples/chat/pom.xml
@@ -32,7 +32,7 @@
     <packaging>pom</packaging>
 
     <properties>
-        <version.javafx>20</version.javafx>
+        <version.javafx>11.0.2</version.javafx>
         <version.javafx.plugin>0.0.8</version.javafx.plugin>
     </properties>
 

--- a/examples/chat/service/src/main/java/org/wildfly/extension/grpc/example/chat/ChatServiceImpl.java
+++ b/examples/chat/service/src/main/java/org/wildfly/extension/grpc/example/chat/ChatServiceImpl.java
@@ -18,9 +18,9 @@ package org.wildfly.extension.grpc.example.chat;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 
-import io.grpc.stub.StreamObserver;
-
 import com.google.protobuf.Timestamp;
+
+import io.grpc.stub.StreamObserver;
 
 public class ChatServiceImpl extends ChatServiceGrpc.ChatServiceImplBase {
 


### PR DESCRIPTION
OpenJFX needs to be downgraded to the Java 11 version. The version 20 requires Java 20 causing compilation of the examples to fail. With this change, enable the `-Pexamples` profile with CI.

Also, a minor update to the README to show how to provision a server with gRPC support.

resolves #89 