### PR TITLE
Resolves #291 Use getAbsolutePort() as this includes the offset.

### DIFF
--- a/subsystem/src/main/java/org/wildfly/extension/grpc/ServerConfiguration.java
+++ b/subsystem/src/main/java/org/wildfly/extension/grpc/ServerConfiguration.java
@@ -63,7 +63,7 @@ class ServerConfiguration {
     }
 
     int getServerPort() {
-        return socketBinding.get().getPort();
+        return socketBinding.get().getAbsolutePort();
     }
 
     String getHostName() {


### PR DESCRIPTION
https://github.com/wildfly-extras/wildfly-grpc-feature-pack/issues/291