### PR TITLE
Exclude dco.txt from license plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -163,6 +163,7 @@
                             <licenseSet>
                                 <header>build-config/src/main/resources/etc/license.txt</header>
                                 <excludes>
+                                    <exclude>dco.txt</exclude>
                                     <exclude>**/.cache/*</exclude>
                                     <exclude>.sdkmanrc</exclude>
                                     <exclude>CODEOWNERS</exclude>


### PR DESCRIPTION
Prerequisite for https://github.com/wildfly-extras/wildfly-grpc-feature-pack/pull/308