### PR TITLE
[#239] Generate documentation for the feature pack

### DIFF
--- a/galleon-pack/common/src/main/resources/layers/standalone/grpc/layer-spec.xml
+++ b/galleon-pack/common/src/main/resources/layers/standalone/grpc/layer-spec.xml
@@ -10,6 +10,8 @@
         <prop name="org.wildfly.rule.add-on" value="rpc,grpc" />
         <prop name="org.wildfly.rule.add-on-depends-on" value="none" />
         <prop name="org.wildfly.rule.add-on-description" value="Support for gRPC." />
+        <prop name="org.wildfly.category" value="RPC (Remote Procdeure Call)"/>
+        <prop name="org.wildfly.description" value="This layer can be used to deploy gRPC services in the application server."/>
     </props>
     <dependencies>
         <layer name="cdi" />

--- a/galleon-pack/feature-pack/pom.xml
+++ b/galleon-pack/feature-pack/pom.xml
@@ -17,7 +17,8 @@
     </parent>
 
     <artifactId>wildfly-grpc-feature-pack</artifactId>
-    <name>WildFly gRPC :: Feature Pack</name>
+    <name>gRPC Feature Pack for WildFly</name>
+    <description>This feature pack provides gRPC capababilities for the WildFly Application Server</description>
     <packaging>pom</packaging>
 
     <properties>

--- a/pom.xml
+++ b/pom.xml
@@ -79,7 +79,7 @@
         <version.checkstyle.plugin>3.1.1</version.checkstyle.plugin>
         <version.enforcer.plugin>3.0.0-M3</version.enforcer.plugin>
         <version.formatter.plugin>2.26.0</version.formatter.plugin>
-        <version.galleon.plugin>7.1.2.Final</version.galleon.plugin>
+        <version.galleon.plugin>8.0.0.Final</version.galleon.plugin>
         <version.impsort.plugin>1.12.0</version.impsort.plugin>
         <version.jandex.plugin>1.2.3</version.jandex.plugin>
         <version.keepachangelog.plugin>2.1.1</version.keepachangelog.plugin>


### PR DESCRIPTION
Bump galleon-plugins to 8.0.0.Final.
A doc.zip archive is generated alongside the zip archive for the feature packs.

Updated feature-pack/pom.xml and layer specs to provide additional information used to generate the documentation.

This doc.zip archive contains all documentation about the feature pack (management API reference, error codes, layers, etc.).

This fixes #239.