### PR TITLE
Add workflow to publish the feature pack documentation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -75,11 +75,10 @@ jobs:
         with:
           branch: gh-pages
           folder: galleon-pack/feature-pack/target/doc/
-          target-folder: doc
           clean: false
       - uses: JamesIves/github-pages-deploy-action@v4.7.3
         with:
           branch: gh-pages
           folder: galleon-pack/feature-pack/target/doc/
-          target-folder: doc/${{ steps.get-version.outputs.version-without-v }}
+          target-folder: ${{ steps.get-version.outputs.version-without-v }}
           clean: false

--- a/README.md
+++ b/README.md
@@ -160,8 +160,8 @@ To see the `chat` example in action, you should start multiple chat clients.
 This feature pack uses the [WildFly Galleon Plugins](https://github.com/wildfly/galleon-plugins) to publish its 
 feature pack documentation. The documentation is available using the following links:
 
-- https://wildfly-extras.github.io/wildfly-grpc/doc/ - Contains the latest documentation
-- https://wildfly-extras.github.io/wildfly-grpc/doc/<sem-version> - Contains the documentation for a specific version
+- https://wildfly-extras.github.io/wildfly-grpc/ - Contains the latest documentation
+- https://wildfly-extras.github.io/wildfly-grpc/<sem-version> - Contains the documentation for a specific version
 
 # Licenses
 


### PR DESCRIPTION
This PR adds a job to the release workflow that publishes the feature pack documentation of that release to 

https://wildfly-extras.github.io/wildfly-grpc-feature-pack/ and 
`https://wildfly-extras.github.io/wildfly-grpc-feature-pack/<sem-version>`
