### PR TITLE
Upgrade Jandex plugin, set compile target to JDK 17, test on 17/21/25

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -8,15 +8,19 @@ on:
 
 jobs:
   build:
-    name: Verify Codebase
+    name: Verify (${{ matrix.java }})
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        java: [ 17, 21, 25 ]
     env:
       MVN: ./mvnw --show-version --batch-mode
     steps:
       - uses: actions/checkout@v7
       - uses: actions/setup-java@v5
         with:
-          java-version: 17
+          java-version: ${{ matrix.java }}
           distribution: temurin
           cache: maven
       - run: $MVN install -Pexamples

--- a/code-parent/pom.xml
+++ b/code-parent/pom.xml
@@ -225,7 +225,7 @@
                 <version>${version.perfmark}</version>
             </dependency>
             <dependency>
-                <groupId>org.jboss.jandex</groupId>
+                <groupId>io.smallrye</groupId>
                 <artifactId>jandex-maven-plugin</artifactId>
                 <version>${version.jandex.plugin}</version>
             </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -84,7 +84,7 @@
         <version.formatter.plugin>2.29.0</version.formatter.plugin>
         <version.galleon.plugin>8.1.0.Final</version.galleon.plugin>
         <version.impsort.plugin>1.13.0</version.impsort.plugin>
-        <version.jandex.plugin>1.2.3</version.jandex.plugin>
+        <version.jandex.plugin>3.2.7</version.jandex.plugin>
         <version.keepachangelog.plugin>2.1.1</version.keepachangelog.plugin>
         <version.license.plugin>5.0.0</version.license.plugin>
         <version.wildfly.plugin>5.1.5.Final</version.wildfly.plugin>
@@ -103,10 +103,10 @@
         <galleon.fork.embedded>true</galleon.fork.embedded>
         <galleon.log.time>true</galleon.log.time>
         <galleon.wildfly.home>/tmp</galleon.wildfly.home>
-        <java.version>17</java.version>
+        <jdk.min.version>17</jdk.min.version>
         <linkXRef>false</linkXRef>
-        <maven.compiler.source>${java.version}</maven.compiler.source>
-        <maven.compiler.target>${java.version}</maven.compiler.target>
+        <maven.compiler.source>${jdk.min.version}</maven.compiler.source>
+        <maven.compiler.target>${jdk.min.version}</maven.compiler.target>
         <maven.min.version>3.9.10</maven.min.version>
         <project.build.sourceEncoding>${encoding}</project.build.sourceEncoding>
         <project.reporting.outputEncoding>${encoding}</project.reporting.outputEncoding>
@@ -244,10 +244,10 @@
                                 <version>${maven.min.version}</version>
                             </requireMavenVersion>
                             <requireJavaVersion>
-                                <message>To build this project JDK ${maven.compiler.source} (or greater) is required.
+                                <message>To build this project JDK ${jdk.min.version} (or greater) is required.
                                     Please install it.
                                 </message>
-                                <version>${maven.compiler.source}</version>
+                                <version>${jdk.min.version}</version>
                             </requireJavaVersion>
                         </rules>
                     </configuration>

--- a/subsystem/pom.xml
+++ b/subsystem/pom.xml
@@ -107,22 +107,12 @@
 
         <!-- WildFly & JBoss -->
         <dependency>
-            <groupId>org.jboss.jandex</groupId>
+            <groupId>io.smallrye</groupId>
             <artifactId>jandex-maven-plugin</artifactId>
         </dependency>
         <dependency>
             <groupId>org.jboss.logging</groupId>
             <artifactId>jboss-logging-annotations</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.jboss.logging</groupId>
-            <artifactId>jboss-logging-processor</artifactId>
-            <!--
-                This is a compile-time dependency of this project, but is not needed at compile or runtime by other
-                projects that depend on this project.
-            -->
-            <scope>provided</scope>
-            <optional>true</optional>
         </dependency>
         <dependency>
             <groupId>org.wildfly.core</groupId>
@@ -154,6 +144,18 @@
         <plugins>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <annotationProcessorPaths>
+                        <path>
+                            <groupId>org.jboss.logging</groupId>
+                            <artifactId>jboss-logging-processor</artifactId>
+                        </path>
+                    </annotationProcessorPaths>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
                 <executions>
                     <execution>
@@ -165,7 +167,7 @@
                 </executions>
             </plugin>
             <plugin>
-                <groupId>org.jboss.jandex</groupId>
+                <groupId>io.smallrye</groupId>
                 <artifactId>jandex-maven-plugin</artifactId>
                 <version>${version.jandex.plugin}</version>
                 <executions>


### PR DESCRIPTION
## Summary

- Upgrade Jandex Maven plugin from `org.jboss.jandex:jandex-maven-plugin:1.2.3` to `io.smallrye:jandex-maven-plugin:3.2.7` (old plugin can't parse JDK 25 class files)
- Set compile target to JDK 17 (`jdk.min.version`) for broader compatibility
- Add JDK matrix (17, 21, 25) to `verify.yml`
- Use JDK 17 for `release.yml` and `doc.yml` workflows

## Comparison with other WildFly feature packs

| Feature Pack | Compile Target | CI JDKs | Release JDK | Release Process |
|---|---|---|---|---|
| **AI** | 17 | 17, 21, 25 | — | Manual `mvn release:prepare/perform` |
| **GraphQL** | 11 (from jboss-parent) | 17, 21 | — | Implied Maven Release Plugin |
| **Datasources** | 17 | 17, 21 | — | Manual `mvn versions:set` + deploy |
| **MyFaces** | 17 | 17 | — | `release.sh` wraps Maven Release Plugin |
| **gRPC (this PR)** | **17** | **17, 21, 25** | **17** | `release.sh` + tag-triggered GH Actions |